### PR TITLE
Retrieving template from fabuloso

### DIFF
--- a/fabuloso/component.py
+++ b/fabuloso/component.py
@@ -43,22 +43,8 @@ class Component(object):
     def set_properties(self, props):
         self._properties = props
 
-    def get_propreties(self, props):
+    def get_properties(self):
         return self._properties
-
-    def get_needed_properties(self):
-        """ Retrieves the list of needed properties"""
-        props = []
-        for service, service_def in self._services.items():
-            service_properties = {}
-            description, methods = service_def
-            for method in methods:
-                params = self._get_method_params(method)
-                for param in params:
-                    if not param in service_properties:
-                        service_properties[param] = ''
-            props.append({service: service_properties})
-        return props
 
     def _set_attributes(self):
         """ Set the dynamically set services. """

--- a/fabuloso/fabuloso.py
+++ b/fabuloso/fabuloso.py
@@ -33,11 +33,45 @@ class Fabuloso(object):
         """ Init with catalog dir"""
         self.catalog = self._load_catalog(catalog_dir)
 
-    def get_component(self, component_name, properties, environment):
+    def init_component(self, component_name, properties, environment):
         comp = self.catalog[component_name]
         comp.set_properties(properties)
         comp.set_environment(environment)
         return comp
+
+    def init_component_extended_data(self, component_name,
+                               ext_properties, environment):
+        properties = {}
+        map(properties.update, ext_properties.values())
+        return self.init_component(component_name, properties, environment)
+
+    def get_template(self, component_name):
+        """ Retrieves the list of needed properties"""
+        component = self.catalog[component_name]
+        props = {}
+        for service, service_def in component._services.items():
+            description, methods = service_def
+            for method in methods:
+                params = component._get_method_params(method)
+                for param in params:
+                    if not param in props:
+                        props[param] = ''
+        return props
+
+    def get_template_extended_data(self, component_name):
+        """ Retrieves the list of needed properties"""
+        component = self.catalog[component_name]
+        props = {}
+        for service, service_def in component._services.items():
+            service_props = {}
+            description, methods = service_def
+            for method in methods:
+                params = component._get_method_params(method)
+                for param in params:
+                    if not param in service_props:
+                        service_props[param] = ''
+            props[service] = service_props
+        return props
 
     def list_components(self):
         """ Return the catalog in a string/json way."""


### PR DESCRIPTION
Retriving the template of a component's properties from the fabuloso
instance instead of from the component's instance. This avoid us of
creating 'void' components with no data to retrieve the properties.

An 'extended' version (with service specific info) of the properties has
been developed as well.
